### PR TITLE
Generate Elm Land as a pre-commit hook

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,15 +45,6 @@ jobs:
       - name: Run tests and linters
         run: devenv test
 
-      # If we forgot to run build before committing, this & next step will catch it.
-      - name: Run codegen
-        shell: devenv shell bash -- -e {0}
-        run: |
-          elm-land build
-
-      - name: Check for uncommitted-changes
-        uses: teamniteo/gha-actions/uncommitted-changes@main
-
       - name: Install SSH key for deployment
         uses: shimataro/ssh-key-action@v2
         if: matrix.os == 'ubuntu-latest'

--- a/README.md
+++ b/README.md
@@ -23,7 +23,6 @@ You need [devenv](https://devenv.sh/). That's it. No fiddling with JS tooling
 nor containers.
 
 ```console
-$ devenv shell
 $ devenv up
 # open http://localhost:8000
 ```

--- a/devenv.nix
+++ b/devenv.nix
@@ -69,6 +69,17 @@ in
 
     # When https://github.com/pre-commit/identify/pull/484 is merged,
     # replace `files` line with this:
+    # types = ["elm"];
+    generate-elm = {
+      enable = true;
+      name = "Generate Elm Land files";
+      entry = "elm-land build";
+      files = ".elm$";
+      pass_filenames = false;
+    };
+
+    # When https://github.com/pre-commit/identify/pull/484 is merged,
+    # replace `files` line with this:
     # types = ["elm" "css" "javascript"];
     generate-css = {
       enable = true;


### PR DESCRIPTION
This helps prevent the need to occasionally run the build command manually before committing changes.